### PR TITLE
Adds ability to set a metric prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,23 +29,38 @@ setInterval(() => {
 }, 500);
 ```
 
+## Naming metrics
+
+You can supply an additional options object to set a prefix for the metric
+names.
+
+```js
+addEventListeners(myBrake, { prefix: 'my_application_prefix_' });
+
+// provides "my_application_prefix_breaker_execute_total" and so on
+```
+
 ## Metrics exposed
 
 This module exposes 9 metrics, all using the name of the `Brake` as the label:
 
-1. `breaker_execute_total`, 'Resolver circuit breaker execute count' (`Counter`)
-2. `breaker_success_total`, 'Resolver circuit breaker success count' (`Counter`)
-3. `breaker_failure_total`, 'Resolver circuit breaker failure count' (`Counter`)
-4. `breaker_timeout_total`, 'Resolver circuit breaker timeout count' (`Counter`)
-5. `breaker_reject_total`, 'Resolver circuit breaker reject count' (`Counter`)
-6. `breaker_circuit_closed_total`, 'Resolver circuit breaker circuit closed
-   count' (`Counter`)
-7. `breaker_circuit_opened_total`, 'Resolver circuit breaker circuit opened
-   count' (`Counter`)
-8. `breaker_duration_seconds`: 'Resolver circuit breaker duration summary'
-   (`Summary`)
-9. `breaker_duration_buckets_seconds`: 'Resolver circuit breaker duration
-   buckets' (`Histogram`)
+1.  `breaker_execute_total`, 'Resolver circuit breaker execute count'
+    (`Counter`)
+2.  `breaker_success_total`, 'Resolver circuit breaker success count'
+    (`Counter`)
+3.  `breaker_failure_total`, 'Resolver circuit breaker failure count'
+    (`Counter`)
+4.  `breaker_timeout_total`, 'Resolver circuit breaker timeout count'
+    (`Counter`)
+5.  `breaker_reject_total`, 'Resolver circuit breaker reject count' (`Counter`)
+6.  `breaker_circuit_closed_total`, 'Resolver circuit breaker circuit closed
+    count' (`Counter`)
+7.  `breaker_circuit_opened_total`, 'Resolver circuit breaker circuit opened
+    count' (`Counter`)
+8.  `breaker_duration_seconds`: 'Resolver circuit breaker duration summary'
+    (`Summary`)
+9.  `breaker_duration_buckets_seconds`: 'Resolver circuit breaker duration
+    buckets' (`Histogram`)
 
 [travis-url]: https://travis-ci.org/finn-no/node-brakes-prometheus
 [travis-image]: https://img.shields.io/travis/finn-no/node-brakes-prometheus.svg
@@ -54,8 +69,10 @@ This module exposes 9 metrics, all using the name of the `Brake` as the label:
 [david-url]: https://david-dm.org/finn-no/node-brakes-prometheus
 [david-image]: https://img.shields.io/david/finn-no/node-brakes-prometheus.svg
 [david-dev-url]: https://david-dm.org/finn-no/node-brakes-prometheus?type=dev
-[david-dev-image]: https://img.shields.io/david/dev/finn-no/node-brakes-prometheus.svg
+[david-dev-image]:
+    https://img.shields.io/david/dev/finn-no/node-brakes-prometheus.svg
 [david-peer-url]: https://david-dm.org/finn-no/node-brakes-prometheus?type=peer
-[david-peer-image]: https://img.shields.io/david/peer/finn-no/node-brakes-prometheus.svg
+[david-peer-image]:
+    https://img.shields.io/david/peer/finn-no/node-brakes-prometheus.svg
 [prom-client-url]: https://github.com/siimon/prom-client
 [brakes-url]: https://github.com/awolden/brakes

--- a/index.js
+++ b/index.js
@@ -9,51 +9,53 @@ const exponentialBuckets = prometheus.exponentialBuckets;
 
 let metrics;
 
-function initializeMetrics() {
+function initializeMetrics(options) {
+    const prefix = options.prefix || '';
+
     metrics = {
         executeCount: new Counter({
-            name: 'breaker_execute_total',
+            name: `${prefix}breaker_execute_total`,
             help: 'Resolver circuit breaker execute count',
             labelNames: ['breaker_name', 'breaker_group'],
         }),
         successCount: new Counter({
-            name: 'breaker_success_total',
+            name: `${prefix}breaker_success_total`,
             help: 'Resolver circuit breaker success count',
             labelNames: ['breaker_name', 'breaker_group'],
         }),
         failureCount: new Counter({
-            name: 'breaker_failure_total',
+            name: `${prefix}breaker_failure_total`,
             help: 'Resolver circuit breaker failure count',
             labelNames: ['breaker_name', 'breaker_group'],
         }),
         timeoutCount: new Counter({
-            name: 'breaker_timeout_total',
+            name: `${prefix}breaker_timeout_total`,
             help: 'Resolver circuit breaker timeout count',
             labelNames: ['breaker_name', 'breaker_group'],
         }),
         healthCheckFailedCount: new Counter({
-            name: 'breaker_reject_total',
+            name: `${prefix}breaker_reject_total`,
             help: 'Resolver circuit breaker reject count',
             labelNames: ['breaker_name', 'breaker_group'],
         }),
         circuitClosedCount: new Counter({
-            name: 'breaker_circuit_closed_total',
+            name: `${prefix}breaker_circuit_closed_total`,
             help: 'Resolver circuit breaker circuit closed count',
             labelNames: ['breaker_name', 'breaker_group'],
         }),
         circuitOpenedCount: new Counter({
-            name: 'breaker_circuit_opened_total',
+            name: `${prefix}breaker_circuit_opened_total`,
             help: 'Resolver circuit breaker circuit opened count',
             labelNames: ['breaker_name', 'breaker_group'],
         }),
         durationSummary: new Summary({
-            name: 'breaker_duration_seconds',
+            name: `${prefix}breaker_duration_seconds`,
             help: 'Resolver circuit breaker duration summary',
             labelNames: ['breaker_name', 'breaker_group'],
             percentiles: [0, 0.25, 0.5, 0.75, 0.9, 0.95, 0.99, 0.995, 1],
         }),
         durationBuckets: new Histogram({
-            name: 'breaker_duration_buckets_seconds',
+            name: `${prefix}breaker_duration_buckets_seconds`,
             help: 'Resolver circuit breaker duration buckets',
             labelNames: ['breaker_name', 'breaker_group'],
             buckets: exponentialBuckets(0.001, 1.5, 20)
@@ -62,9 +64,11 @@ function initializeMetrics() {
         }),
     };
 }
-function addEventsForStats(breaker) {
+function addEventsForStats(breaker, options) {
+    options = options || {};
+
     if (metrics == null) {
-        initializeMetrics();
+        initializeMetrics(options);
     }
 
     const breakerName = breaker.name;
@@ -86,7 +90,6 @@ function addEventsForStats(breaker) {
     breaker.on('success', duration => {
         // Make duration into seconds
         duration /= 1000;
-
         successCount.labels(breakerName, breakerGroup).inc();
 
         durationSummary.labels(breakerName, breakerGroup).observe(duration);

--- a/test.js
+++ b/test.js
@@ -136,3 +136,15 @@ test.serial('return input', t => {
 
     brake.destroy();
 });
+
+test.serial('options can add a prefix', t => {
+    const brake = new Brakes(() => Promise.resolve(), { name: 'some-name' });
+    t.context.module(brake, { prefix: 'some_prefix_' });
+
+    const metrics = register.getMetricsAsJSON();
+    metrics.forEach(metric => {
+        t.true(metric.name.substring(0, 12) === 'some_prefix_');
+    });
+
+    brake.destroy();
+});


### PR DESCRIPTION
Thanks for your module, we have found it useful 😄 

This PR adds the ability to supply an options argument with a `prefix` key. When supplied, the metric names will be prefixed with this string.

This solves our use-case of having a Prometheus instance with many applications' metrics. By adding this option, we can name our metrics appropriately and ensure we don't clash with other applications.

Thank you!